### PR TITLE
userテーブルにuid追加及びそれに伴う変更

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -29,7 +29,7 @@ class Api::V1::UsersController < ApplicationController
   private
 
   def set_user
-    @user = User.find(params[:id])
+    @user = User.find_by!(uid: params[:uid])
   rescue ActiveRecord::RecordNotFound
     render json: { error: 'ユーザーが見つかりません' }, status: :not_found
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,7 +19,8 @@ class SessionsController < ApplicationController
         name: '新規ユーザー',
         email: user_info['info']['email'],
         hunterrank: 1,
-        gender: 'male'
+        gender: 'male',
+        uid: generate_uid
       )
 
       UserAuthentication.create(user_id: user.id, uid: google_user_id, provider:)
@@ -29,6 +30,10 @@ class SessionsController < ApplicationController
   end
 
   private
+
+  def generate_uid
+    SecureRandom.hex(10)
+  end
 
   def generate_token_with_google_user_id(google_user_id, provider)
     exp = Time.now.to_i + 24 * 3600

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  validates :uid, presence: true, uniqueness: true
   validates :email, presence: true, uniqueness: true
   validates :name, presence: true
   validates :gender, presence: true

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :gender
+  attributes :id, :uid, :name, :gender
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
   namespace :api do
     namespace :v1 do
-      resources :users, only: %i[index show update]
+      resources :users, param: :uid, only: %i[index show update]
       get 'users/current', to: 'users#current'
     end
   end

--- a/db/migrate/20240905123833_add_uid_to_users.rb
+++ b/db/migrate/20240905123833_add_uid_to_users.rb
@@ -1,0 +1,6 @@
+class AddUidToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :uid, :string, null: false, unique: true
+    add_index :users, :uid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_04_054553) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_05_123833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,7 +31,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_04_054553) do
     t.string "gender", default: "male", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "uid", null: false
     t.index ["email"], name: "index_users_on_email"
+    t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
   add_foreign_key "user_authentications", "users"


### PR DESCRIPTION
## 概要

userテーブルに`uid`のカラムを追加しました。

## 変更内容

- userテーブルに`uid`追加それに伴うバリデーション,serializerの追加
- user作成じに`uid`も同時に発行する処理追加
- userコントローラ検索を`uid`に変更
- ルートに`uid`のオプション追加

## 確認ポイント

- ログイン時に`uid`が作成できているか
- 既存の挙動は保てているか
- `uid`で検索できるか

## 動作確認

| 一覧GET | 詳細GET |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/7ed71faa4d4b5bca8ac391448d2d0be7.png)](https://gyazo.com/7ed71faa4d4b5bca8ac391448d2d0be7) | [![Image from Gyazo](https://i.gyazo.com/d0c3e410a7cf471faad0c7ff7e656065.png)](https://gyazo.com/d0c3e410a7cf471faad0c7ff7e656065) |
| 変更PATCH | console |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/658ca2bc5657b8f84f891a6e1c0bc307.png)](https://gyazo.com/658ca2bc5657b8f84f891a6e1c0bc307) | [![Image from Gyazo](https://i.gyazo.com/8f46fb50826b72310374096e9bce018d.png)](https://gyazo.com/8f46fb50826b72310374096e9bce018d) |

## 補足

当初、`uid`の方は`integer`型でしたが`string`型に変更しました。