### PR TITLE
既存のユーザーにuidを付与

### DIFF
--- a/db/migrate/20240905123833_add_uid_to_users.rb
+++ b/db/migrate/20240905123833_add_uid_to_users.rb
@@ -1,6 +1,15 @@
 class AddUidToUsers < ActiveRecord::Migration[7.0]
   def change
-    add_column :users, :uid, :string, null: false, unique: true
+    add_column :users, :uid, :string, null: true, unique: true
+
+    User.reset_column_information
+
+    User.find_each do |user|
+      user.update!(uid: SecureRandom.hex(10))
+    end
+
+    change_column_null :users, :uid, false
+
     add_index :users, :uid, unique: true
   end
 end


### PR DESCRIPTION
## 概要

既存のユーザーにuidを付与するマイグレーションの設定を追加しました

## 変更内容

既存のユーザーにuidを付与するマイグレーションの設定を追加しました。これにより、null faluseの制限を避けられるようになりました。