### PR TITLE
 user_uidで行っていた処理をuser_authentications_uidに変更

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -29,7 +29,8 @@ class Api::V1::UsersController < ApplicationController
   private
 
   def set_user
-    @user = User.find_by!(uid: params[:uid])
+    user_authentication = UserAuthentication.find_by!(uid: params[:uid])
+    @user = user_authentication.user
   rescue ActiveRecord::RecordNotFound
     render json: { error: 'ユーザーが見つかりません' }, status: :not_found
   end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -20,7 +20,6 @@ class SessionsController < ApplicationController
         email: user_info['info']['email'],
         hunterrank: 1,
         gender: 'male',
-        uid: generate_uid
       )
 
       UserAuthentication.create(user_id: user.id, uid: google_user_id, provider:)
@@ -30,10 +29,6 @@ class SessionsController < ApplicationController
   end
 
   private
-
-  def generate_uid
-    SecureRandom.hex(10)
-  end
 
   def generate_token_with_google_user_id(google_user_id, provider)
     exp = Time.now.to_i + 24 * 3600

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
-  validates :uid, presence: true, uniqueness: true
+  has_many :user_authentications
+
   validates :email, presence: true, uniqueness: true
   validates :name, presence: true
   validates :gender, presence: true

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :uid, :name, :gender
+  attributes :id, :name, :gender
 end

--- a/db/migrate/20240906071537_remove_uid_from_users.rb
+++ b/db/migrate/20240906071537_remove_uid_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveUidFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_05_123833) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_06_071537) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,9 +31,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_05_123833) do
     t.string "gender", default: "male", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "uid", null: false
     t.index ["email"], name: "index_users_on_email"
-    t.index ["uid"], name: "index_users_on_uid", unique: true
   end
 
   add_foreign_key "user_authentications", "users"


### PR DESCRIPTION
## 概要

 userテーブルのuidで行っていた処理をuser_authenticationsテーブルのuidに変更しました。
 
 ## 変更内容

- userテーブルからuidカラムを削除
-  user_uidで行っていた処理をuser_authentications_uidに変更
- その他uidをユーザー登録時にuidを作成していた箇所の削除

## 動作確認

- [x] userテーブルからuidが削除されているか
- [x] ユーザーのGET,PATCH処理はしっかりおこなえているか

| rails c | GET | PATCH |
| ---- | ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/0ad505380990083c38e42046b45f2d5a.png)](https://gyazo.com/0ad505380990083c38e42046b45f2d5a) | [![Image from Gyazo](https://i.gyazo.com/21bc89c597c49083f7a2770e8a9cfc1f.png)](https://gyazo.com/21bc89c597c49083f7a2770e8a9cfc1f) | [![Image from Gyazo](https://i.gyazo.com/449b8ff0a66ee9c4992aa67e2bb8a5b7.png)](https://gyazo.com/449b8ff0a66ee9c4992aa67e2bb8a5b7) |