### PR TITLE
user-nameに文字制限追加

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   has_many :user_authentications
 
   validates :email, presence: true, uniqueness: true
-  validates :name, presence: true
+  validates :name, length: { maximum: 10 }, presence: true
   validates :gender, presence: true
   validates :hunterrank, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 999 }
 

--- a/db/migrate/20240906113626_add_length_constraint_to_user_name.rb
+++ b/db/migrate/20240906113626_add_length_constraint_to_user_name.rb
@@ -1,0 +1,5 @@
+class AddLengthConstraintToUserName < ActiveRecord::Migration[7.0]
+  def change
+    change_column :users, :name, :string, null: false, limit: 10
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_09_06_071537) do
+ActiveRecord::Schema[7.0].define(version: 2024_09_06_113626) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,7 +26,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_06_071537) do
 
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
-    t.string "name", null: false
+    t.string "name", limit: 10, null: false
     t.integer "hunterrank", default: 1
     t.string "gender", default: "male", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
## 概要

ユーザーの名前の文字制限を追加しました。

## 変更内容

- userモデルにいてバリデーション
- usersテーブルにlimitオプション追加