### PR TITLE
seedにてモンスター,クエストの作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,9 +43,11 @@ gem 'omniauth-rails_csrf_protection'
 gem 'omniauth-google-oauth2'
 gem 'jwt'
 
-
 # jsonデータ整形のためのgem
 gem 'active_model_serializers'
+
+# 日本語を有効にするGem
+gem 'rails-i18n', '~> 7.0.0'
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.8.4)
       actionpack (= 7.0.8.4)
       activesupport (= 7.0.8.4)
@@ -239,6 +242,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.8, >= 7.0.8.4)
+  rails-i18n (~> 7.0.0)
   tzinfo-data
 
 RUBY VERSION

--- a/app/models/monster.rb
+++ b/app/models/monster.rb
@@ -2,5 +2,4 @@ class Monster < ApplicationRecord
   has_many :quests, dependent: :destroy
 
   validates :name, presence: true, uniqueness: true
-  validates :body, presence: true
 end

--- a/db/migrate/20240908054307_create_monsters.rb
+++ b/db/migrate/20240908054307_create_monsters.rb
@@ -2,7 +2,7 @@ class CreateMonsters < ActiveRecord::Migration[7.0]
   def change
     create_table :monsters do |t|
       t.string :name, null: false
-      t.text :body, null: false
+      t.text :body
       t.string :start_battle_image_url
       t.string :end_battle_image_url
       t.string :bestiary_monster_image_url

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_08_063802) do
 
   create_table "monsters", force: :cascade do |t|
     t.string "name", null: false
-    t.text "body", null: false
+    t.text "body"
     t.string "start_battle_image_url"
     t.string "end_battle_image_url"
     t.string "bestiary_monster_image_url"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,7 +8,7 @@
 
 # モンスターを作成
 monster1 = Monster.create!(
-  name: 'フライグ',
+  name: 'フレイグ',
   start_battle_image_url: '/images/monsters/starts/monster1.jpg',
   end_battle_image_url: '/images/monsters/ends/monster1.jpg',
   bestiary_monster_image_url: '/images/monsters/encyclopedias/monster1.jpg'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,70 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+
+# モンスターを作成
+monster1 = Monster.create!(
+  name: 'フライグ',
+  start_battle_image_url: '/images/monsters/starts/monster1.jpg',
+  end_battle_image_url: '/images/monsters/ends/monster1.jpg',
+  bestiary_monster_image_url: '/images/monsters/encyclopedias/monster1.jpg'
+)
+
+monster2 = Monster.create!(
+  name: 'ゲンガオレン',
+  start_battle_image_url: '/images/monsters/starts/monster2.jpg',
+  end_battle_image_url: '/images/monsters/ends/monster2.jpg',
+  bestiary_monster_image_url: '/images/monsters/encyclopedias/monster2.jpg'
+)
+
+monster3 = Monster.create!(
+  name: 'インヴェリオン',
+  start_battle_image_url: '/images/monsters/starts/monster3.jpg',
+  end_battle_image_url: '/images/monsters/ends/monster3.jpg',
+  bestiary_monster_image_url: '/images/monsters/encyclopedias/monster3.jpg'
+)
+
+monster4 = Monster.create!(
+  name: 'ブリゼリーヌ',
+  start_battle_image_url: '/images/monsters/starts/monster4.jpg',
+  end_battle_image_url: '/images/monsters/ends/monster4.jpg',
+  bestiary_monster_image_url: '/images/monsters/encyclopedias/monster4.jpg'
+)
+
+monster5 = Monster.create!(
+  name: 'オージオン',
+  start_battle_image_url: '/images/monsters/starts/monster5.jpg',
+  end_battle_image_url: '/images/monsters/ends/monster5.jpg',
+  bestiary_monster_image_url: '/images/monsters/encyclopedias/monster5.jpg'
+)
+
+# クエストを作成
+Quest.create!(
+  id: 1,
+  title: '焰龍のデスク大掃除',
+  monster: monster1,
+)
+
+Quest.create!(
+  id: 2,
+  title: '雷犬のリビング制圧戦',
+  monster: monster2,
+)
+
+Quest.create!(
+  id: 3,
+  title: '火獣のキッチン浄化',
+  monster: monster3,
+)
+
+Quest.create!(
+  id: 4,
+  title: '氷竜のトイレ氷結戦',
+  monster: monster4,
+)
+
+Quest.create!(
+  id: 5,
+  title: '海龍のバスルーム清掃',
+  monster: monster5,
+)


### PR DESCRIPTION
## 概要

seed.rbにてモンスターとクエストが紐づくデータを作成しました。

## 変更内容

- seed.rbにてクエスト、モンスターのデータ作成
- monsterテーブルのbodyをnill, trueに変更(追加機能で実施します)
- monsterモデルのbodyのバリデーションを削除
- 日本語を有効にするGemを追加

## 動作確認

rails consoleにてデータが保存されているか確認しました。

| quests | monsgers |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/445ee372cb15f1f2bb39dbb374170a7e.png)](https://gyazo.com/445ee372cb15f1f2bb39dbb374170a7e) | [![Image from Gyazo](https://i.gyazo.com/c16322c05140840ab5302152ac8bd406.png)](https://gyazo.com/c16322c05140840ab5302152ac8bd406) |