### PR TITLE
GuildCardコントローラ及びSerializerの設定

### DIFF
--- a/app/controllers/api/v1/guild_cards_controller.rb
+++ b/app/controllers/api/v1/guild_cards_controller.rb
@@ -8,6 +8,17 @@ class Api::V1::GuildCardsController < ApplicationController
     end
   end
 
+  def increment_defeat_count
+    guild_card = GuildCard.find_by(user_id: @current_user.id, monster_id: params[:monster_id])
+
+    if guild_card
+      guild_card.increment!(:defeat_count)
+      render json: guild_card, status: :ok
+    else
+      render json: { error: '該当モンスターのギルドカードが見つかりません' }, status: :not_found
+    end
+  end
+
   private
 
   def guild_card_params

--- a/app/controllers/api/v1/guild_cards_controller.rb
+++ b/app/controllers/api/v1/guild_cards_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::GuildCardsController < ApplicationController
+  def show
+    if @current_user
+      guild_cards = GuildCard.where(user_id: @current_user.id)
+      render json: guild_cards, each_serializer: GuildCardSerializer, status: :ok
+    else
+      render json: { error: '認証情報を取得できません' }, status: :unauthorized
+    end
+  end
+
+  private
+
+  def guild_card_params
+    params.require(:guild_card).permit(:defeat_count)
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -19,8 +19,14 @@ class SessionsController < ApplicationController
         name: '新規ユーザー',
         email: user_info['info']['email'],
         hunterrank: 1,
-        gender: 'male',
+        gender: 'male'
       )
+
+      Monster.all.each do |monster|
+        Rails.logger.info "モンスター: #{monster.name} とユーザー: #{user.id} のために GuildCard を作成しようとしています"
+        guild_card = GuildCard.create!(user_id: user.id, monster_id: monster.id, defeat_count: 0)
+        Rails.logger.info "GuildCard が作成されました: #{guild_card.inspect}"
+      end
 
       UserAuthentication.create(user_id: user.id, uid: google_user_id, provider:)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  has_many :user_authentications
+  has_many :user_authentications, dependent: :destroy
   has_many :user_quests
   has_many :quests, through: :user_quests
   has_many :guild_cards, dependent: :destroy

--- a/app/serializers/guild_card_serializer.rb
+++ b/app/serializers/guild_card_serializer.rb
@@ -1,0 +1,7 @@
+class GuildCardSerializer < ActiveModel::Serializer
+  attributes :id, :defeat_count, :monster_name
+
+  def monster_name
+    object.monster.name
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
       get 'users/current', to: 'users#current'
       resources :quests, only: %i[index show]
       resources :monsters, only: %i[index show]
+      resources :guild_cards, param: :uid, only: [:show]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
       resources :quests, only: %i[index show]
       resources :monsters, only: %i[index show]
       resources :guild_cards, param: :uid, only: [:show]
+      post 'guild_cards/increment_defeat_count', to: 'guild_cards#increment_defeat_count'
     end
   end
 end


### PR DESCRIPTION
## 概要

ユーザーごとのmonsterを討伐数を表示する処理と、討伐数を+1する処理を行いました。

## 変更内容

- app/controllers/sessions_controller.rbにてユーザーログイン時にGuilsCardが生成される処理を追加
- app/controllers/api/v1/guild_cards_controller.rbにて討伐数の表示、更新処理を追加
- GuildCardSerializerの設定
- ルーティング追加

## 動作確認

- [x] ユーザーごとのGuildCardの討伐数が表示される
- [x] ユーザーごとのGuildCardの討伐数が更新される

| GET | POST |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/d2bcca13b4c760b8ae87255817b939bb.png)](https://gyazo.com/d2bcca13b4c760b8ae87255817b939bb) | [![Image from Gyazo](https://i.gyazo.com/257d56d5b2b7b96850423bd3276e0945.png)](https://gyazo.com/257d56d5b2b7b96850423bd3276e0945) |