### PR TITLE
hunteRank上昇api及びserializerの設定

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -34,6 +34,6 @@ class Api::V1::UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:name, :gender)
+    params.require(:user).permit(:name, :gender, :hunterRank)
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::UsersController < ApplicationController
-  before_action :authenticate_request, only: %i[show update current]
+  before_action :authenticate_request, only: %i[show update increment_hunter_rank current]
 
   # API確認用
   def index
@@ -20,6 +20,17 @@ class Api::V1::UsersController < ApplicationController
       render json: @current_user, serializer: UserSerializer, status: :ok
     else
       render json: { errors: @current_user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def increment_hunter_rank
+    user = User.find_by(id: params[:id])
+
+    if user
+      user.increment!(:hunterRank)
+      render json: user, serializer: UserSerializer, status: :ok
+    else
+      render json: { error: '該当ユーザーが見つかりません' }, status: :not_found
     end
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -24,14 +24,13 @@ class Api::V1::UsersController < ApplicationController
   end
 
   def increment_hunter_rank
-    user = User.find_by(id: params[:id])
+    user_authentication = UserAuthentication.find_by!(uid: params[:uid], provider: 'google_oauth2')
+    user = User.find_by!(id: user_authentication.user_id)
 
-    if user
-      user.increment!(:hunterRank)
-      render json: user, serializer: UserSerializer, status: :ok
-    else
-      render json: { error: '該当ユーザーが見つかりません' }, status: :not_found
-    end
+    user.increment!(:hunterRank)
+    render json: user, serializer: UserSerializer, status: :ok
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'ユーザーが見つかりません' }, status: :not_found
   end
 
   def current

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,7 +18,7 @@ class SessionsController < ApplicationController
       user = User.create(
         name: '新規ユーザー',
         email: user_info['info']['email'],
-        hunterrank: 1,
+        hunterRank: 1,
         gender: 'male'
       )
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validates :name, length: { maximum: 10 }, presence: true
   validates :gender, presence: true
-  validates :hunterrank, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 999 }
+  validates :hunterRank, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 999 }
 
   enum gender: { male: 'male', female: 'female', other: 'other' }
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,3 +1,3 @@
 class UserSerializer < ActiveModel::Serializer
-  attributes :id, :name, :gender
+  attributes :id, :name, :gender, :hunterRank
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
       resources :quests, only: %i[index show]
       resources :monsters, only: %i[index show]
       resources :guild_cards, param: :uid, only: [:show]
-      post 'guild_cards/:uid/increment_defeat_count', to: 'guild_cards#increment_defeat_count'
+      patch 'guild_cards/:uid/increment_defeat_count', to: 'guild_cards#increment_defeat_count'
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, param: :uid, only: %i[index show update]
+      patch 'users/:id/increment_hunter_rank', to: 'users#increment_hunter_rank'
       get 'users/current', to: 'users#current'
       resources :quests, only: %i[index show]
       resources :monsters, only: %i[index show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, param: :uid, only: %i[index show update]
-      patch 'users/:id/increment_hunter_rank', to: 'users#increment_hunter_rank'
+      patch 'users/:uid/increment_hunter_rank', to: 'users#increment_hunter_rank'
       get 'users/current', to: 'users#current'
       resources :quests, only: %i[index show]
       resources :monsters, only: %i[index show]

--- a/db/migrate/20240904054539_create_users.rb
+++ b/db/migrate/20240904054539_create_users.rb
@@ -3,7 +3,7 @@ class CreateUsers < ActiveRecord::Migration[7.0]
     create_table :users do |t|
       t.string :email, null: false, unique: true, index: true
       t.string :name, null: false
-      t.integer :hunterrank, default: 1
+      t.integer :hunterRank, default: 1
       t.string :gender, null: false, default: 'male'
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -70,7 +70,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_09_12_053010) do
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "name", limit: 10, null: false
-    t.integer "hunterrank", default: 1
+    t.integer "hunterRank", default: 1
     t.string "gender", default: "male", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## 概要

ユーザーごとのHRを+1上昇するシステム及び、`UserSerilaizer`にhunterRankを追加しました。

## 変更内容

- カラム名の変更(`hunterrank` → `hunterRank`)
- users_controller.rbにHRが+1上昇するメソッド追加及びそれに伴うルートの設定
- `hunterRank`カラムをuser_serializer.rbに追加

## 動作確認

- [x] `http://localhost:3000/api/v1/users/[user_id]/increment_hunter_rank`のエンドポイントからHRが+1できていること

[![Image from Gyazo](https://i.gyazo.com/c6778fd8a701285d514979d280187de6.gif)](https://gyazo.com/c6778fd8a701285d514979d280187de6)