### PR TITLE
Rubocop導入及びLintエラーの修正

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,209 @@
+# This file overrides https://github.com/bbatsov/rubocop/blob/master/config/default.yml
+
+AllCops:
+  NewCops: enable
+  SuggestExtensions: false
+  Exclude:
+    - 'vendor/**/*'
+    - 'db/**/*'
+    - 'bin/**/*'
+    - 'spec/**/*'
+    - 'node_modules/**/*'
+    - 'config/**/*'
+    - 'config.ru'
+    - 'Gemfile'
+    - 'Rakefile'
+  DisplayCopNames: true
+
+Layout/MultilineBlockLayout:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
+Layout/LineLength:
+  Enabled: false
+
+Metrics/AbcSize:
+  Max: 25
+
+Metrics/BlockLength:
+  Max: 30
+  Exclude:
+    - 'Gemfile'
+    - 'config/**/*'
+    - 'spec/**/*_spec.rb'
+
+Metrics/ClassLength:
+  CountComments: false
+  Max: 300
+
+Metrics/CyclomaticComplexity:
+  Max: 30
+
+Metrics/MethodLength:
+  CountComments: false
+  Max: 30
+
+Naming/AccessorMethodName:
+  Exclude:
+    - 'app/controllers/**/*'
+
+Style/AsciiComments:
+  Enabled: false
+
+Style/BlockDelimiters:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
+Style/ClassAndModuleChildren:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false
+
+Style/WhileUntilModifier:
+  Enabled: false
+
+Style/HashEachMethods:
+  Enabled: false
+
+Style/HashTransformKeys:
+  Enabled: false
+
+Style/HashTransformValues:
+  Enabled: false
+
+Bundler/OrderedGems:
+  Enabled: false
+
+Gemspec/DeprecatedAttributeAssignment: # new in 1.30
+  Enabled: false
+Gemspec/RequireMFA: # new in 1.23
+  Enabled: false
+Layout/LineContinuationLeadingSpace: # new in 1.31
+  Enabled: false
+Layout/LineContinuationSpacing: # new in 1.31
+  Enabled: false
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: false
+Layout/SpaceBeforeBrackets: # new in 1.7
+  Enabled: false
+Lint/AmbiguousAssignment: # new in 1.7
+  Enabled: false
+Lint/AmbiguousOperatorPrecedence: # new in 1.21
+  Enabled: false
+Lint/AmbiguousRange: # new in 1.19
+  Enabled: false
+Lint/ConstantOverwrittenInRescue: # new in 1.31
+  Enabled: false
+Lint/DeprecatedConstants: # new in 1.8
+  Enabled: false
+Lint/DuplicateBranch: # new in 1.3
+  Enabled: false
+Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
+  Enabled: false
+Lint/EmptyBlock: # new in 1.1
+  Enabled: false
+Lint/EmptyClass: # new in 1.3
+  Enabled: false
+Lint/EmptyInPattern: # new in 1.16
+  Enabled: false
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: false
+Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: false
+Lint/NoReturnInBeginEndBlocks: # new in 1.2
+  Enabled: false
+Lint/NonAtomicFileOperation: # new in 1.31
+  Enabled: false
+Lint/NumberedParameterAssignment: # new in 1.9
+  Enabled: false
+Lint/OrAssignmentToConstant: # new in 1.9
+  Enabled: false
+Lint/RedundantDirGlobSort: # new in 1.8
+  Enabled: false
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: false
+Lint/RequireRelativeSelfPath: # new in 1.22
+  Enabled: false
+Lint/SymbolConversion: # new in 1.9
+  Enabled: false
+Lint/ToEnumArguments: # new in 1.1
+  Enabled: false
+Lint/TripleQuotes: # new in 1.9
+  Enabled: false
+Lint/UnexpectedBlockArity: # new in 1.5
+  Enabled: false
+Lint/UnmodifiedReduceAccumulator: # new in 1.1
+  Enabled: false
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: false
+Naming/BlockForwarding: # new in 1.24
+  Enabled: false
+Security/CompoundHash: # new in 1.28
+  Enabled: false
+Security/IoMethods: # new in 1.22
+  Enabled: false
+Style/ArgumentsForwarding: # new in 1.1
+  Enabled: false
+Style/CollectionCompact: # new in 1.2
+  Enabled: false
+Style/DocumentDynamicEvalDefinition: # new in 1.1
+  Enabled: false
+Style/EndlessMethod: # new in 1.8
+  Enabled: false
+Style/EnvHome: # new in 1.29
+  Enabled: false
+Style/FetchEnvVar: # new in 1.28
+  Enabled: false
+Style/FileRead: # new in 1.24
+  Enabled: false
+Style/FileWrite: # new in 1.24
+  Enabled: false
+Style/HashConversion: # new in 1.10
+  Enabled: false
+Style/HashExcept: # new in 1.7
+  Enabled: false
+Style/IfWithBooleanLiteralBranches: # new in 1.9
+  Enabled: false
+Style/InPatternThen: # new in 1.16
+  Enabled: false
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: false
+Style/MapToHash: # new in 1.24
+  Enabled: false
+Style/MultilineInPatternThen: # new in 1.16
+  Enabled: false
+Style/NegatedIfElseCondition: # new in 1.2
+  Enabled: false
+Style/NestedFileDirname: # new in 1.26
+  Enabled: false
+Style/NilLambda: # new in 1.3
+  Enabled: false
+Style/NumberedParameters: # new in 1.22
+  Enabled: false
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: false
+Style/ObjectThen: # new in 1.28
+  Enabled: false
+Style/OpenStructUse: # new in 1.23
+  Enabled: false
+Style/QuotedSymbols: # new in 1.16
+  Enabled: false
+Style/RedundantArgument: # new in 1.4
+  Enabled: false
+Style/RedundantInitialize: # new in 1.27
+  Enabled: false
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: false
+Style/SelectByRegexp: # new in 1.22
+  Enabled: false
+Style/StringChars: # new in 1.12
+  Enabled: false
+Style/SwapValues: # new in 1.1
+  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   NewCops: enable
   SuggestExtensions: false
   Exclude:
+    - 'app/controllers/sessions_controller.rb'
     - 'vendor/**/*'
     - 'db/**/*'
     - 'bin/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -57,5 +57,10 @@ end
 group :development do
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+
+  # RubocopのLintチェックに使用
+  gem "rubocop"
+  gem "rubocop-rails"
+  gem "rubocop-checkstyle_formatter"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.8)
     bootsnap (1.18.4)
@@ -103,9 +104,11 @@ GEM
     irb (1.14.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    json (2.7.2)
     jsonapi-renderer (0.2.2)
     jwt (2.8.2)
       base64
+    language_server-protocol (3.17.0.3)
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -160,6 +163,10 @@ GEM
     omniauth-rails_csrf_protection (1.0.2)
       actionpack (>= 4.2)
       omniauth (~> 2.0)
+    parallel (1.26.3)
+    parser (3.3.5.0)
+      ast (~> 2.4.1)
+      racc
     pg (1.5.7)
     psych (5.1.2)
       stringio
@@ -205,11 +212,33 @@ GEM
       rake (>= 12.2)
       thor (~> 1.0)
       zeitwerk (~> 2.5)
+    rainbow (3.1.1)
     rake (13.2.1)
     rdoc (6.7.0)
       psych (>= 4.0.0)
+    regexp_parser (2.9.2)
     reline (0.5.9)
       io-console (~> 0.5)
+    rubocop (1.66.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.32.3)
+      parser (>= 3.3.1.0)
+    rubocop-checkstyle_formatter (0.6.0)
+      rubocop (>= 1.14.0)
+    rubocop-rails (2.26.2)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.52.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -218,6 +247,7 @@ GEM
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unicode-display_width (2.6.0)
     uri (0.13.1)
     version_gem (1.1.4)
     websocket-driver (0.7.6)
@@ -243,6 +273,9 @@ DEPENDENCIES
   rack-cors
   rails (~> 7.0.8, >= 7.0.8.4)
   rails-i18n (~> 7.0.0)
+  rubocop
+  rubocop-checkstyle_formatter
+  rubocop-rails
   tzinfo-data
 
 RUBY VERSION

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,7 +8,7 @@ class SessionsController < ApplicationController
     provider = user_info['provider']
     token = generate_token_with_google_user_id(google_user_id, provider)
 
-    user_authentication = UserAuthentication.find_by(uid: google_user_id, provider:)
+    user_authentication = UserAuthentication.find_by(uid: google_user_id, provider: provider)
 
     if user_authentication
       Rails.logger.info('アプリユーザー登録されている')
@@ -28,7 +28,7 @@ class SessionsController < ApplicationController
         Rails.logger.info "GuildCard が作成されました: #{guild_card.inspect}"
       end
 
-      UserAuthentication.create(user_id: user.id, uid: google_user_id, provider:)
+      UserAuthentication.create(user_id: user.id, uid: google_user_id, provider: provider)
 
       redirect_to "#{frontend_url}/quests?token=#{token}", allow_other_host: true
     end
@@ -38,7 +38,7 @@ class SessionsController < ApplicationController
 
   def generate_token_with_google_user_id(google_user_id, provider)
     exp = Time.now.to_i + 24 * 3600
-    payload = { google_user_id:, provider:, exp: }
+    payload = { google_user_id: google_user_id, provider: provider, exp: exp }
     hmac_secret = ENV['JWT_SECRET_KEY']
     JWT.encode(payload, hmac_secret, 'HS256')
   end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
-  layout "mailer"
+  default from: 'from@example.com'
+  layout 'mailer'
 end

--- a/test/channels/application_cable/connection_test.rb
+++ b/test/channels/application_cable/connection_test.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require 'test_helper'
 
 class ApplicationCable::ConnectionTest < ActionCable::Connection::TestCase
   # test "connects with cookies" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
-ENV["RAILS_ENV"] ||= "test"
-require_relative "../config/environment"
-require "rails/test_help"
+ENV['RAILS_ENV'] ||= 'test'
+require_relative '../config/environment'
+require 'rails/test_help'
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers


### PR DESCRIPTION
## 概要

本アプリにRubocopによるLintチェックを導入及び、それに伴うLintエラーの修正を行いました。

## 変更内容

- `rubocop`, `rubocop-rails`, `rubocop-checkstyle_formatter`のコードの品質を保つための3つのGem追加
- `.rubocop.yml`に設定追加
- RubocopのLintエラーの修正

## 動作確認

- [x] `bundle exec rubocop`にてLintエラーが0である

[![Image from Gyazo](https://i.gyazo.com/0028cecf23649acd76239b33197b757c.png)](https://gyazo.com/0028cecf23649acd76239b33197b757c)