### PR TITLE
各userのdefeated_at一覧を取得

### DIFF
--- a/app/controllers/api/v1/user_quests_controller.rb
+++ b/app/controllers/api/v1/user_quests_controller.rb
@@ -1,6 +1,19 @@
 class Api::V1::UserQuestsController < ApplicationController
   before_action :authenticate_request
 
+  def defeated_records
+    user_auth = UserAuthentication.find_by!(uid: params[:uid])
+    defeated_records = DefeatedRecord.where(user_id: user_auth.user_id).pluck(:defeated_at)
+
+    if defeated_records.present?
+      render json: { defeated_at: defeated_records }, status: :ok
+    else
+      render json: { error: '該当する活動履歴が見つかりません' }, status: :not_found
+    end
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'ユーザーが見つかりません' }, status: :not_found
+  end
+
   def create
     user_quest = UserQuest.find_or_create_by!(
       user_id: @current_user.id,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,15 +2,21 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback', to: 'sessions#create'
   namespace :api do
     namespace :v1 do
+
       resources :users, param: :uid, only: %i[index show update]
       patch 'users/:uid/increment_hunter_rank', to: 'users#increment_hunter_rank'
       get 'users/current', to: 'users#current'
+
       resources :quests, only: %i[index show]
+      
       resources :monsters, only: %i[index show]
+      
       resources :guild_cards, param: :uid, only: [:show]
       patch 'guild_cards/:uid/increment_defeat_count', to: 'guild_cards#increment_defeat_count'
+
       resources :user_quests, only: [:create]
       patch 'user_quests/:quest_id/complete', to: 'user_quests#complete'
+      get 'user_quests/defeated_records/:uid', to: 'user_quests#defeated_records'
     end
   end
 end


### PR DESCRIPTION
## 概要

ユーザーごとの討伐時刻を記録している`defeated_at`一覧を取得する処理を追加しました。

## 変更内容

- `defeated_records`アクションにて`uid`を元に`user_id`を取得
- `pluck`を使って`defeated_at`のみを取得
(今回は`defeated_at`のみあれば良かったので、Serializerの使用は控えました。)

## 動作確認

- [x] `/api/v1/user_quests/defeated_records/[uid]`このリクエストで`defeated_at`の一覧が取得できている
- [x] 存在しないユーザー(uid)の場合は例外処理が働いている

| 存在するuid | 存在しないuid |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/985016a13407849f4a2d1067017164d2.png)](https://gyazo.com/985016a13407849f4a2d1067017164d2) | [![Image from Gyazo](https://i.gyazo.com/6067088edf6bffd30d1570555de8a3b1.png)](https://gyazo.com/6067088edf6bffd30d1570555de8a3b1) |