### PR TITLE
deteat_coutのGET処理完了

### DIFF
--- a/app/controllers/api/v1/guild_cards_controller.rb
+++ b/app/controllers/api/v1/guild_cards_controller.rb
@@ -8,6 +8,15 @@ class Api::V1::GuildCardsController < ApplicationController
     end
   end
 
+  def defeated_records
+    user_auth = UserAuthentication.find_by!(uid: params[:uid])
+    guild_cards = GuildCard.where(user_id: user_auth.user_id)
+
+    render json: guild_cards, each_serializer: GuildCardSerializer, status: :ok
+  rescue ActiveRecord::RecordNotFound
+    render json: { error: 'ユーザーが見つかりません' }, status: :not_found
+  end
+
   def increment_defeat_count
     guild_card = GuildCard.find_by(user_id: @current_user.id, monster_id: params[:monster_id])
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,8 @@ Rails.application.routes.draw do
       
       resources :guild_cards, param: :uid, only: [:show]
       patch 'guild_cards/:uid/increment_defeat_count', to: 'guild_cards#increment_defeat_count'
+      get 'guild_cards/defeated_records/:uid', to: 'guild_cards#defeated_records'
+
 
       resources :user_quests, only: [:create]
       patch 'user_quests/:quest_id/complete', to: 'user_quests#complete'


### PR DESCRIPTION
## 概要

各ユーザーの掃除場所によるグラフを実装するために`deteat_cout`のGET処理を行いました。これにより、各userそれぞれのquestごとの`defeat_cout`が取得できるようになりました。

## 変更内容

- guild_cards_controllerに`defeated_records`アクションを追加
- それに伴うルートの追加

## 動作確認

- [x] `/api/v1/guild_cards/defeated_records/[uid]`この形でそれぞれの`defeat_cout`が取得できている
- [x] 存在しない[uid]が含んだレスポンスがあった際に正しく例外処理が行われている

| 存在する[uid] | 存在しない[uid] |
| ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/e7f4ca52a6560c3ae52f28c978bec04e.png)](https://gyazo.com/e7f4ca52a6560c3ae52f28c978bec04e) | [![Image from Gyazo](https://i.gyazo.com/18b72a7aa76b05d309805336c7040e38.png)](https://gyazo.com/18b72a7aa76b05d309805336c7040e38) |