### PR TITLE
fix/monster_idを昇順でソート

### DIFF
--- a/app/controllers/api/v1/guild_cards_controller.rb
+++ b/app/controllers/api/v1/guild_cards_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::GuildCardsController < ApplicationController
   def show
     if @current_user
-      guild_cards = GuildCard.where(user_id: @current_user.id)
+      guild_cards = GuildCard.where(user_id: @current_user.id).order(monster_id: :asc)
       render json: guild_cards, each_serializer: GuildCardSerializer, status: :ok
     else
       render json: { error: '認証情報を取得できません' }, status: :unauthorized
@@ -10,7 +10,7 @@ class Api::V1::GuildCardsController < ApplicationController
 
   def defeated_records
     user_auth = UserAuthentication.find_by!(uid: params[:uid])
-    guild_cards = GuildCard.where(user_id: user_auth.user_id)
+    guild_cards = GuildCard.where(user_id: user_auth.user_id).order(monster_id: :asc)
 
     render json: guild_cards, each_serializer: GuildCardSerializer, status: :ok
   rescue ActiveRecord::RecordNotFound


### PR DESCRIPTION
## 概要

現状、本番環境のみ`monster_id`の取得方法があいまいで、レイアウトが不確定でレイアウトが乱れていました。
そのため、`monster_id`の取得方法をサーバーサイドで昇順にソート処理しました。

## 変更内容

- showアクション内で取得する`monster_id`を明示的に昇順に変更
- defeated_recordsアクション内で取得する`monster_id`を明示的に昇順に変更
