### PR TITLE
不要なカラム削除及びそれにともなう処理削除

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -17,7 +17,6 @@ class SessionsController < ApplicationController
       Rails.logger.info('まだアプリユーザー登録されていない')
       user = User.create(
         name: '新規ユーザー',
-        email: user_info['info']['email'],
         hunterRank: 1,
         gender: 'male'
       )

--- a/app/models/monster.rb
+++ b/app/models/monster.rb
@@ -3,5 +3,4 @@ class Monster < ApplicationRecord
   has_many :guild_cards
 
   validates :name, presence: true, uniqueness: true
-  validates :body, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,6 @@ class User < ApplicationRecord
   has_many :guild_cards, dependent: :destroy
   has_many :defeated_records, dependent: :destroy
 
-  validates :email, presence: true, uniqueness: true
   validates :name, length: { maximum: 10 }, presence: true
   validates :gender, presence: true
   validates :hunterRank, numericality: { greater_than_or_equal_to: 1, less_than_or_equal_to: 999 }

--- a/app/serializers/monster_serializer.rb
+++ b/app/serializers/monster_serializer.rb
@@ -1,3 +1,3 @@
 class MonsterSerializer < ActiveModel::Serializer
-  attributes :id, :name, :body, :start_battle_image_url, :end_battle_image_url, :bestiary_monster_image_url
+  attributes :id, :name, :start_battle_image_url, :end_battle_image_url, :bestiary_monster_image_url
 end

--- a/db/migrate/20241212042857_remove_body_from_quests.rb
+++ b/db/migrate/20241212042857_remove_body_from_quests.rb
@@ -1,0 +1,5 @@
+class RemoveBodyFromQuests < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :quests, :body, :text
+  end
+end

--- a/db/migrate/20241212043848_remove_body_from_monsters.rb
+++ b/db/migrate/20241212043848_remove_body_from_monsters.rb
@@ -1,0 +1,5 @@
+class RemoveBodyFromMonsters < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :monsters, :body, :text
+  end
+end

--- a/db/migrate/20241212044510_remove_email_from_users.rb
+++ b/db/migrate/20241212044510_remove_email_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveEmailFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_12_042857) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_12_043848) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,7 +39,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_12_042857) do
 
   create_table "monsters", force: :cascade do |t|
     t.string "name", null: false
-    t.text "body", null: false
     t.string "start_battle_image_url"
     t.string "end_battle_image_url"
     t.string "bestiary_monster_image_url"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_10_09_060315) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_12_042857) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,7 +50,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_10_09_060315) do
 
   create_table "quests", force: :cascade do |t|
     t.string "title", null: false
-    t.text "body"
     t.bigint "monster_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_12_12_043848) do
+ActiveRecord::Schema[7.0].define(version: 2024_12_12_044510) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -76,13 +76,11 @@ ActiveRecord::Schema[7.0].define(version: 2024_12_12_043848) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.string "email", null: false
     t.string "name", limit: 10, null: false
     t.integer "hunterRank", default: 1
     t.string "gender", default: "male", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email"
   end
 
   add_foreign_key "defeated_records", "quests"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,7 +9,6 @@
 # モンスターを作成
 monster1 = Monster.create!(
   name: 'フレイグ',
-  body: 'フレイグは火を操る強大なモンスターです。',
   start_battle_image_url: '/images/monsters/starts/monster1.jpg',
   end_battle_image_url: '/images/monsters/ends/monster1.jpg',
   bestiary_monster_image_url: '/images/monsters/encyclopedias/monster1.jpg'
@@ -17,7 +16,6 @@ monster1 = Monster.create!(
 
 monster2 = Monster.create!(
   name: 'ゲンガオレン',
-  body: 'ゲンガオレンは雷を操る巨大な犬の姿をしています。',
   start_battle_image_url: '/images/monsters/starts/monster2.jpg',
   end_battle_image_url: '/images/monsters/ends/monster2.jpg',
   bestiary_monster_image_url: '/images/monsters/encyclopedias/monster2.jpg'
@@ -25,7 +23,6 @@ monster2 = Monster.create!(
 
 monster3 = Monster.create!(
   name: 'インヴェリオン',
-  body: 'インヴェリオンは強力な火を吹く獣です。',
   start_battle_image_url: '/images/monsters/starts/monster3.jpg',
   end_battle_image_url: '/images/monsters/ends/monster3.jpg',
   bestiary_monster_image_url: '/images/monsters/encyclopedias/monster3.jpg'
@@ -33,7 +30,6 @@ monster3 = Monster.create!(
 
 monster4 = Monster.create!(
   name: 'ブリゼリーヌ',
-  body: 'ブリゼリーヌは冷気を操る氷竜です。',
   start_battle_image_url: '/images/monsters/starts/monster4.jpg',
   end_battle_image_url: '/images/monsters/ends/monster4.jpg',
   bestiary_monster_image_url: '/images/monsters/encyclopedias/monster4.jpg'
@@ -41,7 +37,6 @@ monster4 = Monster.create!(
 
 monster5 = Monster.create!(
   name: 'オージオン',
-  body: 'オージオンは海の力を持つ巨大な龍です。',
   start_battle_image_url: '/images/monsters/starts/monster5.jpg',
   end_battle_image_url: '/images/monsters/ends/monster5.jpg',
   bestiary_monster_image_url: '/images/monsters/encyclopedias/monster5.jpg'


### PR DESCRIPTION
## 概要

使用していないカラムを削除し、それに伴いバリデーション、シリアライザーの削除を行いました。

## 変更内容

- questsテーブルから`body`カラム削除

- monstersテーブルから`body`カラム削除
  - モデルのバリデーション削除
  - シリアライザーの削除
  - seedデータから`body`を削除
 
- usersテーブルから`email`カラム削除
  - モデルのバリデーション削除
  - 認証の際のコントローラの記述削除

## 動作確認

- [x] schemaファイルでそれぞれのテーブルからカラムが削除されていること

| quests | monsters | users |
| ---- | ---- | ---- |
| [![Image from Gyazo](https://i.gyazo.com/d972b9097916e14c9a7b6c204dcb7552.png)](https://gyazo.com/d972b9097916e14c9a7b6c204dcb7552) | [![Image from Gyazo](https://i.gyazo.com/3c6ddec2797f32e6ac376da62f595eb5.png)](https://gyazo.com/3c6ddec2797f32e6ac376da62f595eb5) | [![Image from Gyazo](https://i.gyazo.com/1a336e8716a8b0bf63dd0a1bdc5fec66.png)](https://gyazo.com/1a336e8716a8b0bf63dd0a1bdc5fec66) |